### PR TITLE
Require node 4+ and npm 3+ to install package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 1.0.0 (Not Released Yet)
 ========================
 
+1.0.0-beta.5 (2016-07-25)
+=========================
+
+* Require node.js 4 LTS or higher and npm 3 to use `eslint-config-ezhome`
+* Install ESLint dependencies via `package.json`, which results in unnecessary
+  to install them via `devDependencies`
+* New rule to `ezhome/alternate` config:
+  * `react/jsx-no-string-refs`
+
 1.0.0-beta.4 (2016-07-20)
 =========================
 

--- a/README.md
+++ b/README.md
@@ -7,30 +7,34 @@ eslint-config-ezhome
 
 This package provides Ezhome's `.eslintrc` as an extensible shared config.
 
+## Requirements
+
+As of `1.0.0` release `eslint-config-ezhome` requires,
+
+* [node.js](https://www.nodejs.org/) 4.4 or later
+* [npm](https://www.npmjs.com/) 3.10 or later
+
 ## Usage
 
 1. Install `eslint-config-ezhome` and some other ESLint dev dependencies as,
 
    ```
-   npm install --save-dev eslint babel-eslint esling-plugin-import-order eslint-plugin-react eslint-config-ezhome
+   npm install --save-dev eslint-config-ezhome
    ```
-
-   If your project doesn't use React, you don't need to install
-   `eslint-plugin-react` dev dep.
 
 2. Add `"extends": "ezhome"` to your `.eslintrc`
 
 ### Note on preferred ESLint versions
 
-As of `1.0.0` release, `eslint-config-ezhome` prefers:
+As of `1.0.0` release, `eslint-config-ezhome` installs:
 
 * `eslint@3.1.1`
 * `babel-eslint@6.1.2`
 * `eslint-plugin-import-order@2.1.4`
 * `eslint-plugin-react@5.2.2`
 
-You still able to install other versions of ESLint packages, but we recommend
-use versions listed above.
+as its requirements. You still able to install other versions of ESLint
+packages, but we recommend use versions listed above.
 
 ## Other Configs
 

--- a/alternate/index.js
+++ b/alternate/index.js
@@ -8,6 +8,7 @@ if (utils.reactPluginInstalled) {
     config.rules["react/jsx-handler-names"] = 2;
     config.rules["react/jsx-indent"] = [2, 2];
     config.rules["react/jsx-indent-props"] = [2, 2];
+    config.rules["react/jsx-no-string-refs"] = 2;
 }
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-ezhome",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "author": "Igor Davydenko",
   "authorEmail": "igor@ezhome.com",
   "bugs": {
@@ -22,13 +22,15 @@
     "url": "https://github.com/ezhome/eslint-config-ezhome"
   },
   "dependencies": {
-    "object-assign": "4.1.0"
-  },
-  "devDependencies": {
     "babel-eslint": "6.1.2",
     "eslint": "3.1.1",
     "eslint-plugin-import-order": "2.1.4",
-    "eslint-plugin-react": "5.2.2"
+    "eslint-plugin-react": "5.2.2",
+    "object-assign": "4.1.0"
+  },
+  "engines": {
+    "node": ">= 4",
+    "npm": ">= 3"
   },
   "eslintConfig": {
     "extends": "ezhome/base/index.js"


### PR DESCRIPTION
Which results in installing ESLint dependencies via `package.json` `dependencies` list.

Also add new rule to `ezhome/alternate` config.
